### PR TITLE
feat: add S3 sink credential and endpoint override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,60 @@ if result.getErrorByStep().size() > 0:
   print("Some events failed validation")
 ```
 
+### S3 Sink
+
+Output processed data to Amazon S3:
+
+```python
+# Basic S3 sink (uses default AWS credential chain)
+flow = (
+    zephflow.ZephFlow.start_flow()
+    .filter("$.value > 10")
+    .eval("""
+        dict(
+            id=$.id,
+            processed_value=$.value * 2,
+            timestamp=now()
+        )
+    """)
+    .s3_sink(
+        region="us-west-2",
+        bucket="processed-data-bucket",
+        folder="events/year=2024/month=01/",
+        encoding_type="JSON_OBJECT"
+    )
+)
+
+# S3 sink with explicit credentials
+flow = (
+    zephflow.ZephFlow.start_flow()
+    .filter("$.status == 'active'")
+    .s3_sink(
+        region="us-east-1",
+        bucket="my-data-bucket",
+        folder="processed/daily/",
+        encoding_type="JSON_OBJECT",
+        access_key_id="AKIAIOSFODNN7EXAMPLE",
+        secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    )
+)
+
+# S3 sink with custom endpoint (for MinIO or S3-compatible storage)
+flow = (
+    zephflow.ZephFlow.start_flow()
+    .filter("$.priority == 'high'")
+    .s3_sink(
+        region="us-west-2",
+        bucket="minio-bucket",
+        folder="high-priority/",
+        encoding_type="JSON_OBJECT",
+        access_key_id="minioadmin",
+        secret_access_key="minioadmin",
+        s3_endpoint_override="http://localhost:9000"
+    )
+)
+```
+
 ## S3 Dead Letter Queue (DLQ)
 
 ZephFlow supports automatic error handling by storing failed events to Amazon S3 using a Dead Letter Queue mechanism. **S3 DLQ works with data sources** (like file_source, kafka_source, etc.) and captures events that fail during **data ingestion, conversion, or pipeline processing** (including filter, assertion, eval failures).

--- a/zephflow/core.py
+++ b/zephflow/core.py
@@ -305,6 +305,8 @@ class ZephFlow:
         bucket: str,
         folder: str,
         encoding_type: str,
+        access_key_id: Optional[str] = None,
+        secret_access_key: Optional[str] = None,
         s3_endpoint_override: Optional[str] = None,
     ):
         """
@@ -315,6 +317,8 @@ class ZephFlow:
             bucket: S3 bucket name
             folder: Folder path within the bucket
             encoding_type: Encoding type for the output (e.g., "JSON_OBJECT")
+            access_key_id: Optional AWS access key ID
+            secret_access_key: Optional AWS secret access key
             s3_endpoint_override: Optional endpoint override for S3 compatibility
 
         Returns:
@@ -326,12 +330,17 @@ class ZephFlow:
             encoding_type
         )
 
-        if s3_endpoint_override:
-            new_java_flow = self._java_flow.s3Sink(
-                region, bucket, folder, java_encoding_type, s3_endpoint_override
+        # Create credential object if both access_key_id and secret_access_key are provided
+        credential = None
+        if access_key_id and secret_access_key:
+            credential = ZephFlow._jvm.io.fleak.zephflow.lib.credentials.UsernamePasswordCredential(
+                access_key_id, secret_access_key
             )
-        else:
-            new_java_flow = self._java_flow.s3Sink(region, bucket, folder, java_encoding_type)
+
+        # Use the new unified Java API
+        new_java_flow = self._java_flow.s3Sink(
+            region, bucket, folder, java_encoding_type, credential, s3_endpoint_override
+        )
 
         return ZephFlow(new_java_flow)
 


### PR DESCRIPTION
  - Support optional access_key_id/secret_access_key parameters in s3_sink()
  - Add s3_endpoint_override for MinIO/S3-compatible storage
  - Update README with S3 sink usage examples